### PR TITLE
feat: Add datetime conversion logic and enhance service/utils functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bsky-sdk",
+ "chrono",
  "rmcp",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.98"
 bsky-sdk = "0.1.19"
+chrono = "0.4.41"
 rmcp = "0.1"
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.44.2", features = ["io-std", "rt-multi-thread"] }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,16 @@
-use anyhow::{Result, anyhow};
-use bsky_sdk::{BskyAgent, api::com::atproto};
+use anyhow::anyhow;
+use bsky_sdk::{
+    BskyAgent,
+    api::{com::atproto, types::string::Datetime},
+};
+use chrono::Local;
+use rmcp::serde_json::{self, Map, Value};
+use serde::Serialize;
 
 pub async fn get_post(
     agent: &BskyAgent,
     at_uri: &str,
-) -> Result<atproto::repo::get_record::Output> {
+) -> anyhow::Result<atproto::repo::get_record::Output> {
     let parts = at_uri
         .strip_prefix("at://")
         .ok_or(anyhow!("invalid AT URI"))?
@@ -32,4 +38,41 @@ pub async fn get_post(
             .into(),
         )
         .await?)
+}
+
+pub fn convert_datetime<S>(data: S) -> Result<Value, serde_json::Error>
+where
+    S: Serialize,
+{
+    let value = serde_json::to_value(data)?;
+    fn recursive(value: Value) -> Result<Value, serde_json::Error> {
+        Ok(match value {
+            Value::Object(map) => {
+                let mut new_map = Map::new();
+                for (key, value) in map {
+                    if key.ends_with("At") {
+                        if let Value::String(datetime_str) = &value {
+                            if let Ok(datetime) = datetime_str.parse::<Datetime>() {
+                                let local_dt = datetime.as_ref().with_timezone(&Local);
+                                let converted =
+                                    Datetime::new(local_dt.with_timezone(local_dt.offset()));
+                                new_map.insert(key, serde_json::to_value(converted)?);
+                                continue;
+                            }
+                        }
+                    }
+                    new_map.insert(key, recursive(value)?);
+                }
+                Value::Object(new_map)
+            }
+            Value::Array(array) => Value::Array(
+                array
+                    .into_iter()
+                    .map(recursive)
+                    .collect::<Result<Vec<_>, _>>()?,
+            ),
+            _ => value,
+        })
+    }
+    recursive(value)
 }


### PR DESCRIPTION
This pull request introduces a utility function to convert datetime strings to localized datetime objects and integrates it into the `BskyService` methods to ensure consistent datetime handling. It also includes minor dependency updates and code cleanup.

### New Utility Functionality:
* [`src/utils.rs`](diffhunk://#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80R42-R78): Added a `convert_datetime` function to recursively process JSON-like data structures, converting datetime strings ending with "At" into localized datetime objects using the `chrono` and `bsky-sdk` libraries.

### Integration of `convert_datetime`:
* [`src/service.rs`](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23L74-R80): Updated multiple methods in the `BskyService` implementation to use the `convert_datetime` function, ensuring datetime fields are localized and properly handled. This includes error handling for datetime conversion failures. [[1]](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23L74-R80) [[2]](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23L115-R126) [[3]](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23L155-R186) [[4]](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23R278-R289)

### Dependency Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R9): Added `chrono` as a new dependency to support datetime localization.

### Code Cleanup:
* [`src/service.rs`](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23L1-R6): Reorganized imports to remove unused entries and group related imports together. [[1]](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23L1-R6) [[2]](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23R29)
* [`src/utils.rs`](diffhunk://#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80L1-R13): Removed unused imports and streamlined the `get_post` function signature.