### PR TITLE
feat: Update parameters to use Option types

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1,7 +1,7 @@
 use crate::{
     types::{
-        CreatePostParams, GetAuthorFeedParams, GetPostThreadParams, ListNotificationsParams,
-        ReasonEnum, default_limit,
+        CreatePostParams, DEFAULT_DEPTH, DEFAULT_LIMIT, DEFAULT_PARENT_HEIGHT, GetAuthorFeedParams,
+        GetPostThreadParams, ListNotificationsParams, ReasonEnum,
     },
     utils::{convert_datetime, get_post},
 };
@@ -89,11 +89,7 @@ impl BskyService {
         let actor = params.actor.parse().map_err(|e: &str| {
             Error::internal_error("failed to parse actor", Some(Value::String(e.into())))
         })?;
-        let limit = Some(
-            LimitedNonZeroU8::<100u8>::try_from(params.limit).map_err(|e| {
-                Error::internal_error("failed to parse limit", Some(Value::String(e.to_string())))
-            })?,
-        );
+        let limit = params.limit.unwrap_or(DEFAULT_LIMIT).try_into().ok();
         let output = self
             .agent
             .api
@@ -131,16 +127,16 @@ impl BskyService {
         &self,
         #[tool(aggr)] params: GetPostThreadParams,
     ) -> Result<CallToolResult, Error> {
-        let depth = Some(LimitedU16::<1000u16>::try_from(params.depth).map_err(|e| {
-            Error::internal_error("failed to parse depth", Some(Value::String(e.to_string())))
-        })?);
+        let depth = Some(
+            LimitedU16::<1000u16>::try_from(params.depth.unwrap_or(DEFAULT_DEPTH)).map_err(
+                |e| Error::internal_error("failed to parse depth", Some(Value::String(e))),
+            )?,
+        );
         let parent_height = Some(
-            LimitedU16::<1000u16>::try_from(params.parent_height).map_err(|e| {
-                Error::internal_error(
-                    "failed to parse parent height",
-                    Some(Value::String(e.to_string())),
-                )
-            })?,
+            LimitedU16::<1000u16>::try_from(params.parent_height.unwrap_or(DEFAULT_PARENT_HEIGHT))
+                .map_err(|e| {
+                    Error::internal_error("failed to parse parent height", Some(Value::String(e)))
+                })?,
         );
         let output = self
             .agent
@@ -192,11 +188,8 @@ impl BskyService {
     async fn get_unreplied_mentions(
         &self,
         #[tool(param)]
-        #[schemars(
-            description = "Maximum number of notifications to retrieve.",
-            default = "default_limit"
-        )]
-        max_num: u8,
+        #[schemars(description = "Maximum number of notifications to retrieve.")]
+        max_num: Option<u8>,
     ) -> Result<CallToolResult, Error> {
         // Get the recent notifications that are replies or mentions
         let notifications = self
@@ -294,9 +287,9 @@ impl BskyService {
         params: ListNotificationsParams,
     ) -> Result<Vec<bsky::notification::list_notifications::Notification>, Error> {
         let limit = Some(
-            LimitedNonZeroU8::<100u8>::try_from(params.limit).map_err(|e| {
-                Error::internal_error("failed to parse limit", Some(Value::String(e.to_string())))
-            })?,
+            LimitedNonZeroU8::<100u8>::try_from(params.limit.unwrap_or(DEFAULT_LIMIT)).map_err(
+                |e| Error::internal_error("failed to parse limit", Some(Value::String(e))),
+            )?,
         );
         let output = self
             .agent

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,39 +2,26 @@ use rmcp::schemars::{self, JsonSchema};
 use serde::Deserialize;
 use std::fmt;
 
+pub const DEFAULT_LIMIT: u8 = 10;
+pub const DEFAULT_DEPTH: u16 = 1;
+pub const DEFAULT_PARENT_HEIGHT: u16 = 10;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetAuthorFeedParams {
     #[schemars(description = "Handle or DID of account to fetch author feed of.")]
     pub actor: String,
-    #[schemars(
-        description = "Limit for the number of posts to fetch.",
-        default = "default_limit"
-    )]
-    pub limit: u8,
+    #[schemars(description = "Limit for the number of posts to fetch.")]
+    pub limit: Option<u8>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetPostThreadParams {
     #[schemars(description = "Reference (AT-URI) to post record.")]
     pub uri: String,
-    #[schemars(
-        description = "How many levels of reply depth should be included in response.",
-        default = "default_depth"
-    )]
-    pub depth: u16,
-    #[schemars(
-        description = "How many levels of parent (and grandparent, etc) post to include.",
-        default = "default_parent_height"
-    )]
-    pub parent_height: u16,
-}
-
-fn default_depth() -> u8 {
-    1
-}
-
-fn default_parent_height() -> u8 {
-    10
+    #[schemars(description = "How many levels of reply depth should be included in response.")]
+    pub depth: Option<u16>,
+    #[schemars(description = "How many levels of parent (and grandparent, etc) post to include.")]
+    pub parent_height: Option<u16>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -70,17 +57,10 @@ impl fmt::Display for ReasonEnum {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListNotificationsParams {
-    #[schemars(
-        description = "Limit for the number of notifications to fetch.",
-        default = "default_limit"
-    )]
-    pub limit: u8,
+    #[schemars(description = "Limit for the number of notifications to fetch.")]
+    pub limit: Option<u8>,
     #[schemars(description = "Notification reasons to include in response.")]
     pub reasons: Vec<ReasonEnum>,
-}
-
-pub fn default_limit() -> u8 {
-    10
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]


### PR DESCRIPTION
This pull request refactors the handling of default parameter values in the `BskyService` and associated types to improve code clarity and maintainability. Key changes include replacing in-line default value functions with centralized constants, modifying parameter types to use `Option` for optional values, and simplifying logic for applying defaults.

### Refactoring of Default Parameter Handling:

* Replaced in-line default value functions (`default_limit`, `default_depth`, `default_parent_height`) with constants: `DEFAULT_LIMIT`, `DEFAULT_DEPTH`, and `DEFAULT_PARENT_HEIGHT` in `src/types.rs`. These constants are now used throughout the codebase for consistency.

* Updated parameter types in `GetAuthorFeedParams`, `GetPostThreadParams`, and `ListNotificationsParams` to use `Option` for optional fields, removing the need for default attributes in `schemars` annotations. [[1]](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0R5-R24) [[2]](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0L73-L85)

### Simplification of Default Value Application:

* Simplified logic in `BskyService` methods (`get_author_feed`, `get_post_thread`, `list_notifications`) by using `unwrap_or` with the new constants to apply default values. This eliminates the need for separate error-handling code when parsing default values. [[1]](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23L92-R92) [[2]](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23L134-R138) [[3]](diffhunk://#diff-5c6f87176b7f64fbbeabbc31f5ad377edc268ebeb231eb55ee31c14ec3834f23L297-R292)

* Updated the `get_unreplied_mentions` method to accept an `Option<u8>` for `max_num`, aligning its behavior with the new approach to optional parameters.