### PR TITLE
Release for v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.10](https://github.com/sugyan/bsky-rmcp/compare/v0.0.9...v0.0.10) - 2025-05-15
+- feat: Update parameters to use Option types by @sugyan in https://github.com/sugyan/bsky-rmcp/pull/16
+
 ## [v0.0.9](https://github.com/sugyan/bsky-rmcp/compare/v0.0.8...v0.0.9) - 2025-05-15
 - feat: Update post creation parameters to use Option for reply URI by @sugyan in https://github.com/sugyan/bsky-rmcp/pull/15
 


### PR DESCRIPTION
This pull request is for the next release as v0.0.10 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.10 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.9" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: Update parameters to use Option types by @sugyan in https://github.com/sugyan/bsky-rmcp/pull/16


**Full Changelog**: https://github.com/sugyan/bsky-rmcp/compare/v0.0.9...v0.0.10