### PR TITLE
fix: add length constraint to post text description in CreatePostParams

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -65,7 +65,7 @@ pub struct ListNotificationsParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CreatePostParams {
-    #[schemars(description = "Text content of the post.")]
+    #[schemars(description = "Text content of the post.", length(max = 300))]
     pub text: String,
     #[schemars(description = "Optional URI of the post being replied to.")]
     pub reply: Option<String>,


### PR DESCRIPTION
This pull request includes a small update to the `CreatePostParams` struct in `src/types.rs`. The change adds a maximum length constraint of 300 characters to the `text` field description.

* [`src/types.rs`](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0L68-R68): Updated the `#[schemars]` attribute for the `text` field in the `CreatePostParams` struct to include a `length(max = 300)` constraint.